### PR TITLE
Update 2.0 modules to use ZIO 2.0-RC6

### DIFF
--- a/modules/cassandra-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/cassandra/ZCassandraContainerSpec.scala
+++ b/modules/cassandra-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/cassandra/ZCassandraContainerSpec.scala
@@ -4,7 +4,7 @@ import zio._
 import zio.test._
 import zio.test.Assertion._
 
-object ZCassandraContainerSpec extends DefaultRunnableSpec {
+object ZCassandraContainerSpec extends ZIOSpecDefault {
 
   def spec = suite("ZCassandraContainerSpec")(
     test("Should start up a Cassandra container, execute against that container and then close it.") {

--- a/modules/db-migration-aspect-zio-2.0/src/test/scala/io/github/scottweaver/zio/aspect/DbMigrationAspectSpec.scala
+++ b/modules/db-migration-aspect-zio-2.0/src/test/scala/io/github/scottweaver/zio/aspect/DbMigrationAspectSpec.scala
@@ -7,7 +7,7 @@ import TestAspect.sequential
 import io.github.scottweaver.zio.testcontainers.mysql.ZMySQLContainer
 import java.sql.Connection
 
-object DbMigrationAspectSpec extends DefaultRunnableSpec {
+object DbMigrationAspectSpec extends ZIOSpecDefault {
   def spec = suite("DatabaseMigrationAspect")(
     test("Should run Flyway migrations from the default location e.g. 'classpath:db/migration'.") {
 

--- a/modules/mysql-zio-2.0/src/main/scala/io/github/scottweaver/zio/testcontainers/mysql/ZMySQLContainer.scala
+++ b/modules/mysql-zio-2.0/src/main/scala/io/github/scottweaver/zio/testcontainers/mysql/ZMySQLContainer.scala
@@ -31,7 +31,7 @@ object ZMySQLContainer {
   val live = {
 
     def makeManagedConnection(container: MySQLContainer) =
-      ZManaged.acquireReleaseWith(
+      ZIO.acquireRelease(
         ZIO.attempt {
           DriverManager.getConnection(
             container.jdbcUrl,
@@ -47,7 +47,7 @@ object ZMySQLContainer {
       )
 
     def makeManagedContainer(settings: Settings) =
-      ZManaged.acquireReleaseWith(
+      ZIO.acquireRelease(
         ZIO.attempt {
           val containerDef = MySQLContainer.Def(
             dockerImageName = DockerImageName.parse(s"mysql:${settings.imageVersion}"),
@@ -64,9 +64,9 @@ object ZMySQLContainer {
           .ignore
       )
 
-    ZLayer.fromManagedEnvironment {
+    ZLayer.scopedEnvironment {
       for {
-        settings  <- ZIO.service[Settings].toManaged
+        settings  <- ZIO.service[Settings]
         container <- makeManagedContainer(settings)
         conn      <- makeManagedConnection(container)
 

--- a/modules/mysql-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/mysql/ZMySQLContainerSpec.scala
+++ b/modules/mysql-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/mysql/ZMySQLContainerSpec.scala
@@ -7,7 +7,7 @@ import java.sql.Connection
 import com.dimafeng.testcontainers.MySQLContainer
 import io.github.scottweaver.models.JdbcInfo
 
-object ZMySQLContainerSpec extends DefaultRunnableSpec {
+object ZMySQLContainerSpec extends ZIOSpecDefault {
   def spec =
     suite("ZMySQLContainerSpec")(
       test("Should start up a MySQL container that can be queried.") {

--- a/modules/postgresql-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/postgresql/ZPostgreSQLContainerSpec.scala
+++ b/modules/postgresql-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/postgresql/ZPostgreSQLContainerSpec.scala
@@ -7,7 +7,7 @@ import java.sql.Connection
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import io.github.scottweaver.models.JdbcInfo
 
-object ZPostgreSQLContainerSpec extends DefaultRunnableSpec {
+object ZPostgreSQLContainerSpec extends ZIOSpecDefault {
   def spec =
     suite("ZPostgreSQLContainerSpec")(
       test("Should start up a Postgres continer that can be queried.") {

--- a/project/V.scala
+++ b/project/V.scala
@@ -5,7 +5,7 @@ object V {
   val scala3Version              = "3.1.2"
   val supportedScalaVersions     = List(scala213Version, scala212Version, scala3Version)
   val zioVersion                 = "1.0.13"
-  val zio2Version                = "2.0.0-RC2"
+  val zio2Version                = "2.0.0-RC6"
   val zioMagicVersion            = "0.3.10"
   val zioKafkaVersion            = "0.17.1"
   val testcontainersScalaVersion = "0.40.2"


### PR DESCRIPTION
Does what the title does, also did a check with `docker ps` to make sure that no lingering docker images are present after running the tests. 