### PR TITLE
add beforeAll variation of migrate

### DIFF
--- a/modules/db-migration-aspect-zio-2.0/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
+++ b/modules/db-migration-aspect-zio-2.0/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
@@ -35,7 +35,7 @@ object DbMigrationAspect {
         .orDie
     )
 
-  def migrateBeforeAll(
+  def migrateOnce(
     migrationLocations: String*
   )(configureCallback: ConfigurationCallback = identity) =
     beforeAll(

--- a/modules/db-migration-aspect-zio-2.0/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
+++ b/modules/db-migration-aspect-zio-2.0/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
@@ -1,10 +1,11 @@
 package io.github.scottweaver.zio.aspect
 
 import zio._
-import zio.test.TestAspect.before
+import zio.test.TestAspect.{ before, beforeAll }
 import io.github.scottweaver.models.JdbcInfo
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.configuration.FluentConfiguration
+import zio.test.TestAspect
 
 object DbMigrationAspect {
 
@@ -26,11 +27,22 @@ object DbMigrationAspect {
       flyway.migrate
     }
 
-  def migrate(mirgationLocations: String*)(configureCallback: ConfigurationCallback = identity) = before(
-    ZIO
-      .service[JdbcInfo]
-      .flatMap(jdbcInfo => doMigrate(jdbcInfo, configureCallback, mirgationLocations: _*))
-      .orDie
-  )
+  def migrate(mirgationLocations: String*)(configureCallback: ConfigurationCallback = identity) =
+    before(
+      ZIO
+        .service[JdbcInfo]
+        .flatMap(jdbcInfo => doMigrate(jdbcInfo, configureCallback, mirgationLocations: _*))
+        .orDie
+    )
+
+  def migrateBeforeAll(
+    migrationLocations: String*
+  )(configureCallback: ConfigurationCallback = identity) =
+    beforeAll(
+      ZIO
+        .service[JdbcInfo]
+        .flatMap(jdbcInfo => doMigrate(jdbcInfo, configureCallback, migrationLocations: _*))
+        .orDie
+    )
 
 }

--- a/modules/db-migration-aspect/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
+++ b/modules/db-migration-aspect/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
@@ -1,7 +1,7 @@
 package io.github.scottweaver.zio.aspect
 
 import zio._
-import zio.test.TestAspect.before
+import zio.test.TestAspect.{ before, beforeAll }
 import io.github.scottweaver.models.JdbcInfo
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.configuration.FluentConfiguration
@@ -32,5 +32,13 @@ object DbMigrationAspect {
       .flatMap(jdbcInfo => doMigrate(jdbcInfo, configureCallback, migrationLocations: _*))
       .orDie
   )
+
+  def migrateBeforeAll(migrationLocations: String*)(configureCallback: ConfigurationCallback = identity) =
+    beforeAll(
+      ZIO
+        .service[JdbcInfo]
+        .flatMap(jdbcInfo => doMigrate(jdbcInfo, configureCallback, migrationLocations: _*))
+        .orDie
+    )
 
 }

--- a/modules/db-migration-aspect/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
+++ b/modules/db-migration-aspect/src/main/scala/io/github/scottweaver/zio/aspect/DbMigrationAspect.scala
@@ -33,7 +33,7 @@ object DbMigrationAspect {
       .orDie
   )
 
-  def migrateBeforeAll(migrationLocations: String*)(configureCallback: ConfigurationCallback = identity) =
+  def migrateOnce(migrationLocations: String*)(configureCallback: ConfigurationCallback = identity) =
     beforeAll(
       ZIO
         .service[JdbcInfo]


### PR DESCRIPTION
Addresses #19 

I added a variation of `migrate` which runs once rather than once per test. I'm not sure that the naming is clear, however, since  `migrate` does not necessarily indicate that it's done for each test. @scottweaver Would there be a more appropriate alternative to `migrateBeforeAll`?