### PR TITLE
dot "." instead of "-" in the kafka dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ libraryDependencies += "io.github.scottweaver" %% "zio-testcontainers-kafka" % "
 
 ### ZIO 2.x
 ```scala
-libraryDependencies += "io.github.scottweaver" %% "zio-2.0-testcontainers-kafka" % "0.8.0"
+libraryDependencies += "io.github.scottweaver" %% "zio-2-0-testcontainers-kafka" % "0.8.0"
 ```
 
 


### PR DESCRIPTION
There's a lil typo in the path, which will cause the lib to not be found.

( The Line 213 seems to got some invisble change by the GitHub web edit, maybe a new line )