### PR TITLE
Add LocalStack (V1) container for zio 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ lazy val root = project
     cassandraZio2,
     `cassandra-migration-aspect`,
     `cassandra-migration-aspect-Zio2`,
-    solrZio2
+    solrZio2,
+    localstackZio2
     // docs
   )
 
@@ -266,6 +267,29 @@ lazy val solrZio2 =
       libraryDependencies ++= Seq(
         "com.dimafeng" %% "testcontainers-scala-solr" % V.testcontainersScalaVersion,
         "dev.zio"      %% "zio-http"                  % V.zioHttpVersion % Test
+      )
+    )
+
+lazy val localstackZio2 =
+  project
+    .in(file("modules/localstack-zio-2.0"))
+    .settings(
+      zioSeries := ZIOSeries.Series2X,
+      testcontainersScalaSettings,
+      name := "zio-2.0-testcontainers-localstack",
+      libraryDependencies ++= Seq(
+        "com.dimafeng" %% "testcontainers-scala-localstack" % V.testcontainersScalaVersion,
+        "com.amazonaws" % "aws-java-sdk-s3"                 % V.awsV1Version  % Provided,
+        "com.amazonaws" % "aws-java-sdk-sqs"                % V.awsV1Version  % Provided,
+        "dev.zio"      %% "zio-aws-s3"                      % V.zioAwsVersion % Test,
+        "dev.zio"      %% "zio-aws-netty"                   % V.zioAwsVersion % Test
+      )
+    )
+    .settings(
+      Test / envVars ++= Map(
+        "AWS_ACCESS_KEY_ID"     -> "local",
+        "AWS_SECRET_ACCESS_KEY" -> "secret",
+        "AWS_REGION"            -> "us-east-1"
       )
     )
 

--- a/modules/localstack-zio-2.0/src/main/scala/io/github/scottweaver/zio/testcontainers/localstack/ZLocalStackContainer.scala
+++ b/modules/localstack-zio-2.0/src/main/scala/io/github/scottweaver/zio/testcontainers/localstack/ZLocalStackContainer.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 io.github.scottweaver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.scottweaver.zio.testcontainers.localstack
+
+import com.dimafeng.testcontainers.LocalStackContainer
+import zio._
+
+object ZLocalStackContainer {
+
+  type Settings = LocalStackContainer.Def
+
+  object Settings {
+
+    val default: ULayer[Settings] =
+      ZLayer.succeed(LocalStackContainer.Def())
+
+    def withServices(services: LocalStackContainer.Service*): ULayer[Settings] =
+      ZLayer.succeed(LocalStackContainer.Def(services = services))
+
+  }
+
+  val live: ZLayer[Settings, Nothing, LocalStackContainer] =
+    ZLayer.scoped {
+      for {
+        settings  <- ZIO.service[Settings]
+        container <- makeContainer(settings)
+      } yield container
+    }
+
+  def makeContainer(settings: Settings): ZIO[Scope, Nothing, LocalStackContainer] =
+    ZIO.acquireRelease(ZIO.attempt(settings.start()).orDie)(container => ZIO.attempt(container.stop()).ignoreLogged)
+
+}

--- a/modules/localstack-zio-2.0/src/test/resources/logback-test.xml
+++ b/modules/localstack-zio-2.0/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+      <layout class="ch.qos.logback.classic.PatternLayout">
+        <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} %msg%n</Pattern>
+      </layout>
+    </encoder>
+  </appender>
+
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="org.testcontainers" level="WARN" />
+  <logger name="com.github.dockerjava" level="WARN" />
+  <logger name="ch.qos.logback" level="WARN" />
+</configuration>

--- a/modules/localstack-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/localstack/ZLocalStackContainerSpec.scala
+++ b/modules/localstack-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/localstack/ZLocalStackContainerSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 io.github.scottweaver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.scottweaver.zio.testcontainers.localstack
+
+import com.dimafeng.testcontainers.LocalStackContainer
+import org.testcontainers.containers.localstack.{LocalStackContainer => JavaLocalStackContainer}
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import zio._
+import zio.aws.core.config.{AwsConfig, CommonAwsConfig}
+import zio.aws.netty.NettyHttpClient
+import zio.aws.s3.S3
+import zio.aws.s3.model.CreateBucketRequest
+import zio.aws.s3.model.primitives.BucketName
+import zio.test.Assertion._
+import zio.test._
+
+object ZLocalStackContainerSpec extends ZIOSpecDefault {
+
+  override def spec =
+    suite("ZLocalStackContainerSpec")(
+      test("Should start a LocalStack container and create S3 bucket") {
+        val testCase =
+          for {
+            s3              <- ZIO.service[S3]
+            _               <- s3.createBucket(CreateBucketRequest(bucket = BucketName("foo")))
+            listBuckets     <- s3.listBuckets().flatMap(_.getBuckets)
+            listBucketNames <- ZIO.foreach(listBuckets)(_.getName)
+          } yield assert(listBucketNames)(equalTo(List(BucketName("foo"))))
+
+        testCase
+      }
+    ).provideShared(
+      ZLocalStackContainer.Settings.withServices(JavaLocalStackContainer.Service.S3),
+      ZLocalStackContainer.live,
+      s3Layer,
+      AwsConfig.configured(),
+      commonAwsConfigLayer,
+      NettyHttpClient.default
+    )
+
+  private def s3Layer: RLayer[LocalStackContainer with AwsConfig, S3] =
+    ZLayer.scoped {
+      for {
+        localstack <- ZIO.service[LocalStackContainer]
+        endpoint   <- ZIO.attempt(localstack.container.getEndpointOverride(JavaLocalStackContainer.Service.S3))
+        s3         <- S3.scoped(_.endpointOverride(endpoint))
+      } yield s3
+    }
+
+  private def commonAwsConfigLayer: ULayer[CommonAwsConfig] =
+    ZLayer.succeed(
+      CommonAwsConfig(
+        region = Some(software.amazon.awssdk.regions.Region.US_EAST_1),
+        credentialsProvider = DefaultCredentialsProvider.builder().build(),
+        endpointOverride = None,
+        commonClientConfig = None
+      )
+    )
+
+}

--- a/modules/localstack-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/localstack/ZLocalStackContainerSpec.scala
+++ b/modules/localstack-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/localstack/ZLocalStackContainerSpec.scala
@@ -39,7 +39,7 @@ object ZLocalStackContainerSpec extends ZIOSpecDefault {
             _               <- s3.createBucket(CreateBucketRequest(bucket = BucketName("foo")))
             listBuckets     <- s3.listBuckets().flatMap(_.getBuckets)
             listBucketNames <- ZIO.foreach(listBuckets)(_.getName)
-          } yield assert(listBucketNames)(equalTo(List(BucketName("foo"))))
+          } yield assert(listBucketNames)(equalTo(List("foo")))
 
         testCase
       }

--- a/project/V.scala
+++ b/project/V.scala
@@ -12,6 +12,8 @@ object V {
   val zioKafkaVersion            = "0.17.1"
   val zio2KafkaVersion           = "2.0.0"
   val zioHttpVersion             = "0.0.4"
+  val zioAwsVersion              = "5.20.17.1"
+  val awsV1Version               = "1.11.479"
   val testcontainersScalaVersion = "0.40.10"
   val mysqlConnnectorJVersion    = "8.0.29"
   val postgresqlDriverVersion    = "42.3.3"

--- a/project/V.scala
+++ b/project/V.scala
@@ -14,7 +14,7 @@ object V {
   val zioHttpVersion             = "0.0.4"
   val zioAwsVersion              = "5.20.17.1"
   val awsV1Version               = "1.11.479"
-  val testcontainersScalaVersion = "0.40.10"
+  val testcontainersScalaVersion = "0.40.15"
   val mysqlConnnectorJVersion    = "8.0.29"
   val postgresqlDriverVersion    = "42.3.3"
   val slf4jVersion               = "1.7.32"


### PR DESCRIPTION
This PR adds LocalStack container V1 for ZIO 2.0 only. 

~I also opened another PR in `testcontainers-scala` to allow `dockerImageName` overrides, and not only `tag`: https://github.com/testcontainers/testcontainers-scala/pull/246. I think it would be good to wait until the `testcontainers-scala` PR is merged and make changes to this one accordingly.~
Update: `testcontainers-scala` is bumped up to `0.40.15`