### PR TITLE
Update ZIO 2 and zio prelude version

### DIFF
--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/Command.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/Command.scala
@@ -60,6 +60,7 @@ object Command {
           )
         case 404 => CommandFailure.imageNotFound(self, image)
         case 409 =>
+          import DockerErrorMessage.DockerErrorMessageDecoder
           CommandFailure
             .decodeResponse[DockerErrorMessage](body, self)
             .flatMap(msg =>

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/DockerContainerFailure.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/DockerContainerFailure.scala
@@ -100,8 +100,10 @@ object CommandFailure {
       UnexpectedHttpError(cause, command, uri)
     }.flatMap(r => command.makeResponse(r, ""))
 
-  def unexpectedDockerApiError(body: String, command: Command, statusCode: Int): DockerIO[Any, command.Response] =
+  def unexpectedDockerApiError(body: String, command: Command, statusCode: Int): DockerIO[Any, command.Response] = {
+    import DockerErrorMessage.DockerErrorMessageDecoder
     decodeResponse[DockerErrorMessage](body, command).flatMap { message =>
       ZIO.fail(UnexpectedDockerApiError(message, command, statusCode))
     }
+  }
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/Interpreter.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/Interpreter.scala
@@ -18,6 +18,8 @@ package io.github.scottweaver.zillen
 
 import io.github.scottweaver.zillen.Command.StopContainer.{NotRunning, Stopped}
 import io.github.scottweaver.zillen.Command._
+import io.github.scottweaver.zillen.Command.RemoveContainer.Force.{Syntax => ForceSyntax}
+import io.github.scottweaver.zillen.Command.RemoveContainer.Volumes.{Syntax => VolumesSyntax}
 import io.github.scottweaver.zillen.models.CreateContainerRequest
 import io.github.scottweaver.zillen.netty.NettyRequestHandler
 import io.netty.buffer.{ByteBuf, Unpooled}

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/CreateContainerRequest.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/CreateContainerRequest.scala
@@ -28,5 +28,7 @@ final case class CreateContainerRequest(
 )
 
 object CreateContainerRequest {
+  import Env.EnvEncoder
+  import Image.ImageCodec
   implicit val encoder: JsonEncoder[CreateContainerRequest] = DeriveJsonEncoder.gen
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/CreateContainerResponse.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/CreateContainerResponse.scala
@@ -26,5 +26,6 @@ final case class CreateContainerResponse(
 )
 
 object CreateContainerResponse {
+  import ContainerId.ContainerIdCodec
   implicit val createContainerResponseDecoder: JsonDecoder[CreateContainerResponse] = DeriveJsonDecoder.gen
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/CreateImageResponse.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/CreateImageResponse.scala
@@ -39,6 +39,7 @@ object CreateImageResponse {
     implicit val IdDecoder: JsonDecoder[Id] = JsonDecoder.string.map(wrap(_))
   }
 
+  import CreateImageResponse.Id.IdDecoder
   implicit val CreateImageResponseDecoder: JsonDecoder[CreateImageResponse] = DeriveJsonDecoder.gen[CreateImageResponse]
 
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/HostConfig.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/HostConfig.scala
@@ -28,6 +28,7 @@ object HostConfig {
 
   val empty = HostConfig(PortMap.empty)
 
+  import PortMap.PortMapCodec
   implicit val HostConfigCodec: JsonCodec[HostConfig] = DeriveJsonCodec.gen[HostConfig]
 
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/HostInterface.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/HostInterface.scala
@@ -52,5 +52,6 @@ object HostInterface {
   private[zillen] def makeUnsafeFromPort(hostPort: Int): HostInterface =
     HostInterface(None, HostPort.unsafeMake(hostPort))
 
+  import HostPort.hostPortCodec
   implicit val hostInterfaceCode: JsonCodec[HostInterface] = DeriveJsonCodec.gen[HostInterface]
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/InspectContainerResponse.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/InspectContainerResponse.scala
@@ -28,6 +28,7 @@ final case class InspectContainerResponse(
 )
 
 object InspectContainerResponse {
+  import ContainerName.ContainerNameCodec
   implicit val inspectContainerResponseJson: JsonDecoder[InspectContainerResponse] =
     DeriveJsonDecoder.gen
 }

--- a/modules/core/src/main/scala/io/github/scottweaver/zillen/models/NetworkSettings.scala
+++ b/modules/core/src/main/scala/io/github/scottweaver/zillen/models/NetworkSettings.scala
@@ -25,6 +25,7 @@ final case class NetworkSettings(
 )
 
 object NetworkSettings {
+  import PortMap.PortMapCodec
   implicit val networkSettingsCodec: JsonCodec[NetworkSettings] =
     DeriveJsonCodec.gen[NetworkSettings]
 }

--- a/modules/postgresql-zio-2.0/src/main/scala/io/github/scottweaver/zio/testcontainers/postgresql/PostgresContainer.scala
+++ b/modules/postgresql-zio-2.0/src/main/scala/io/github/scottweaver/zio/testcontainers/postgresql/PostgresContainer.scala
@@ -51,6 +51,8 @@ final class PostgresContainer
     }
 
   private def makeUrl(portMap: PortMap, settings: PostgresContainer.Settings) = {
+    import io.github.scottweaver.zillen.models.PortMap.Syntax
+
     val hostInterface = portMap.findExternalHostPort(5432, Docker.protocol.TCP)
     val user          = settings.username.getOrElse("postgres")
     val databaseName  = settings.databaseName.getOrElse(user)
@@ -112,6 +114,7 @@ object PostgresContainer {
     additionalEnv: Env,
     imageName: String = "postgres"
   ) {
+    import io.github.scottweaver.zillen.models.Env.Syntax
 
     private[postgresql] def toEnv: Env =
       Docker

--- a/modules/postgresql-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/postgresql/PostgresContainerSpec.scala
+++ b/modules/postgresql-zio-2.0/src/test/scala/io/github/scottweaver/zio/testcontainers/postgresql/PostgresContainerSpec.scala
@@ -18,6 +18,7 @@ package io.github.scottweaver.zio.testcontainers.postgres
 
 import io.github.scottweaver.models.JdbcInfo
 import io.github.scottweaver.zillen.Docker
+import io.github.scottweaver.zillen.models.PortMap.{Syntax => PortMapSyntax}
 import io.github.scottweaver.zillen.models._
 import io.github.scottweaver.zio.testcontainers.postgresql._
 import zio._

--- a/project/V.scala
+++ b/project/V.scala
@@ -5,9 +5,9 @@ object V {
   val scala3Version              = "3.2.2"
   val supportedScalaVersions     = List(scala213Version, scala212Version, scala3Version)
   val zio1xVersion               = "1.0.15"
-  val zio2xVersion               = "2.0.9"
+  val zio2xVersion               = "2.0.15"
   val zioJsonVersion             = "0.4.2"
-  val zioPreludeVersion          = "1.0.0-RC15"
+  val zioPreludeVersion          = "1.0.0-RC19"
   val zioMagicVersion            = "0.3.10"
   val zioKafkaVersion            = "0.17.1"
   val zio2KafkaVersion           = "2.0.0"


### PR DESCRIPTION
I am trying to use this library in my project that depends on zio-http 0.0.5, which depends on zio-prelude 1.0.0-RC16. It seems to be binary incompatible with zio-prelude 1.0.0-RC15 so updating zio2xVersion and zioPreludeVersion to latest versions. Can you please have a look at it?